### PR TITLE
[Feature/#10] 로그인 페이지 퍼블리싱

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ const Welcome: React.FC<WelcomeProps> = ({ name }) => {
 - 딕셔너리, 배열 등의 복수의 데이터를 담는 자료구조에 대한 변수명 s 붙이기 `ex) heights`
 - 로딩이나 모달창 등의 보여짐 여부에 대한 boolean state의 경우 is 붙이기 `ex) isModalOpen, isLoading`
 - 데이터 접근 함수의 경우 get으로 시작하기 `ex) getUserData`
-- 컴포넌트 내부에서 동작하는 함수는 handle 붙이기 `ex) handleClick, handleModalOpen`
-- prop으로 받아서 동작하는 함수는 on 붙이기 `ex) onClick, onClose`
+- 이벤트를 감지하는 함수는 on으로 시작하며, 이 함수는 주로 이벤트 발생 시점에 호출됩니다 ex) onClick, onClose
+- 이벤트 처리 로직을 담는 함수는 handle로 시작하며, 주로 on 함수 내에서 호출됩니다 ex) handleClick, handleModalOpen
 
 | 함수명 | 동사구 ex) getUserData |
 | ------ | ---------------------- |

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -6,7 +6,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   className?: string;
 }
 
-function Button({ children, className, ...props }: ButtonProps) {
+const Button: React.FC<ButtonProps> = ({ children, className, ...props }) => {
   return (
     <button
       type="button"
@@ -19,6 +19,6 @@ function Button({ children, className, ...props }: ButtonProps) {
       {children}
     </button>
   );
-}
+};
 
 export default Button;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,6 +1,7 @@
 const routes = Object.freeze({
   signIn: "/sign-in",
   signUp: "/sign-up",
+  password: "/password",
 });
 
 export default routes;

--- a/src/pages/FindPassword/index.tsx
+++ b/src/pages/FindPassword/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const FindPasswordPage: React.FC = () => {
+  return <div>FindPasswordPage</div>;
+};
+
+export default FindPasswordPage;

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -1,5 +1,106 @@
-const SignInPage = () => {
-  return <div>SignInPage</div>;
+import Button from "@components/Button";
+import Input from "@components/Input";
+import routes from "@constants/routes";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { Link } from "react-router-dom";
+
+type SignInFormData = {
+  email: string;
+  password: string;
+};
+
+const SignInPage: React.FC = () => {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<SignInFormData>();
+
+  const [email, password] = watch(["email", "password"]);
+
+  const onSubmit: SubmitHandler<SignInFormData> = (data) => {
+    console.log(data);
+  };
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="flex h-[580px] w-[500px] flex-col bg-white px-[70px] shadow-form">
+        <h2 className="mt-[62px] text-4xl font-semibold">로그인</h2>
+        <Link
+          to={routes.signUp}
+          className="text-base font-normal text-title underline"
+        >
+          아직 계정이 없으신가요?
+        </Link>
+        <form onSubmit={handleSubmit(onSubmit)} noValidate>
+          <div className="mt-10 flex flex-col gap-10">
+            <div className="relative flex flex-col gap-2">
+              <label className="text-sm font-semibold text-title">이메일</label>
+              <Input
+                type="email"
+                placeholder="이메일(E-mail) 주소를 입력해주세요."
+                maxLength={24}
+                isInvalid={!!errors.email}
+                {...register("email", {
+                  required: true,
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: "*잘못된 이메일 형식입니다.",
+                  },
+                })}
+              />
+              {errors.email && (
+                <p className="absolute -bottom-5 left-4 text-xs font-regular text-error">
+                  {errors.email?.message?.toString()}
+                </p>
+              )}
+            </div>
+            <div className="relative flex flex-col gap-2">
+              <label className="text-sm font-semibold text-title">
+                비밀번호
+              </label>
+              <Input
+                type="password"
+                placeholder="비밀번호를 입력해주세요."
+                maxLength={24}
+                isInvalid={!!errors.password}
+                {...register("password", {
+                  required: true,
+                  minLength: {
+                    value: 8,
+                    message: "*비밀번호가 잘못 되었습니다.",
+                  },
+                  pattern: {
+                    value:
+                      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/,
+                    message: "*비밀번호가 잘못 되었습니다.",
+                  },
+                })}
+              />
+              {errors.password && (
+                <p className="absolute -bottom-5 left-4 text-xs font-regular text-error">
+                  {errors.password?.message?.toString()}
+                </p>
+              )}
+            </div>
+          </div>
+          <Button
+            type="submit"
+            disabled={!(email && password)}
+            className="mt-[60px] w-full py-3"
+          >
+            다음
+          </Button>
+        </form>
+        <Link
+          to={routes.password}
+          className="mt-3 w-full text-center text-xs font-regular text-body1"
+        >
+          비밀번호 찾기
+        </Link>
+      </div>
+    </div>
+  );
 };
 
 export default SignInPage;

--- a/src/pages/SignUp/components/Step1/index.tsx
+++ b/src/pages/SignUp/components/Step1/index.tsx
@@ -4,7 +4,11 @@ import { ChangeEvent, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import PasswordCondition from "./PasswordCondtion";
 
-const Step1 = ({ handleNext }: { handleNext: () => void }) => {
+interface Step1Props {
+  handleNext: () => void;
+}
+
+const Step1: React.FC<Step1Props> = ({ handleNext }) => {
   const {
     register,
     watch,
@@ -12,8 +16,7 @@ const Step1 = ({ handleNext }: { handleNext: () => void }) => {
     formState: { errors },
   } = useFormContext();
 
-  const email = watch("email");
-  const password = watch("password");
+  const [email, password] = watch(["email", "password"]);
 
   const [isVerificationButtonEnabled, setIsVerificationButtonEnabled] =
     useState(false);

--- a/src/pages/SignUp/components/Step2/index.tsx
+++ b/src/pages/SignUp/components/Step2/index.tsx
@@ -3,7 +3,11 @@ import { Checkbox } from "@chakra-ui/react";
 import Button from "@components/Button";
 import { useFormContext } from "react-hook-form";
 
-const Step2 = ({ handleBack }: { handleBack: () => void }) => {
+interface Step2Props {
+  handleBack: () => void;
+}
+
+const Step2: React.FC<Step2Props> = ({ handleBack }) => {
   const {
     register,
     formState: { errors, isValid },

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import { useForm, FormProvider } from "react-hook-form";
+import { useForm, FormProvider, SubmitHandler } from "react-hook-form";
 import Step1 from "./components/Step1";
 import Step2 from "./components/Step2";
 
-type FormData = {
+type SingUpFormData = {
   email: string;
   password: string;
   companyName: string;
@@ -12,14 +12,14 @@ type FormData = {
   agreement: boolean;
 };
 
-const SignUpPage = () => {
+const SignUpPage: React.FC = () => {
   const [step, setStep] = useState(1);
-  const methods = useForm<FormData>();
+  const methods = useForm<SingUpFormData>();
 
   const handleNext = () => setStep(2);
   const handleBack = () => setStep(1);
 
-  const onSubmit = (data: FormData) => {
+  const handleSubmit: SubmitHandler<SingUpFormData> = (data) => {
     console.log(data);
   };
 
@@ -28,7 +28,7 @@ const SignUpPage = () => {
       <div className="flex h-[660px] w-[500px] flex-col overflow-hidden bg-white shadow-form">
         <FormProvider {...methods}>
           <form
-            onSubmit={methods.handleSubmit(onSubmit)}
+            onSubmit={methods.handleSubmit(handleSubmit)}
             className="relative w-full"
           >
             <div

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -3,6 +3,7 @@ import SignInPage from "@pages/SignIn";
 import SignUpPage from "@pages/SignUp";
 import { createBrowserRouter } from "react-router-dom";
 import App from "./App";
+import FindPasswordPage from "@pages/FindPassword";
 
 const router = createBrowserRouter([
   {
@@ -16,6 +17,10 @@ const router = createBrowserRouter([
       {
         path: routes.signUp,
         element: <SignUpPage />,
+      },
+      {
+        path: routes.password,
+        element: <FindPasswordPage />,
       },
     ],
   },


### PR DESCRIPTION
## 💻 관련 이슈

<!--
ex) close #100
-->

- close #10

## 💡 작업내용

- 로그인 페이지 퍼블리싱
- 리액트 훅 폼 연결
- 버튼 컴포넌트, 다른 컴포넌트들 타입 변경 (React.FC 까먹고 안함)
- 비밀번호 찾기 페이지 추가

## 🧐 참고 사항

- on, handle 네이밍 규칙 변경

## 🖼️ 스크린샷

https://github.com/user-attachments/assets/c91a859d-4e4a-4c2e-9443-4de131f5ffb1


## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
