### PR TITLE
[Feature/#26] 로그인, 회원가입 버튼 및 로고 라우팅 기능 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx eslint . --fix
 npx prettier --write .
 npx lint-staged
 npx tsc --noEmit

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.59.9",
         "@tanstack/react-query-devtools": "^5.59.9",
         "axios": "^1.7.7",
+        "class-variance-authority": "^0.7.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "prettier-plugin-tailwindcss": "^0.6.8",
@@ -3173,6 +3174,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "2.0.0"
+      },
+      "funding": {
+        "url": "https://joebell.co.uk"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -3343,6 +3356,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query": "^5.59.9",
     "@tanstack/react-query-devtools": "^5.59.9",
     "axios": "^1.7.7",
+    "class-variance-authority": "^0.7.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "prettier-plugin-tailwindcss": "^0.6.8",

--- a/src/api/hooks/accounts/usePostSignIn.ts
+++ b/src/api/hooks/accounts/usePostSignIn.ts
@@ -1,5 +1,6 @@
 import { postSignIn } from "@api/accountsAPI";
 import { PostSignInData } from "@api/types/accounts";
+import routes from "@constants/routes";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
@@ -8,7 +9,7 @@ const usePostSignIn = () => {
   return useMutation({
     mutationFn: (singInData: PostSignInData) => postSignIn(singInData),
     onSuccess: () => {
-      navigate("/");
+      navigate(routes.dashboard);
     },
   });
 };

--- a/src/api/hooks/accounts/usePostSignUp.ts
+++ b/src/api/hooks/accounts/usePostSignUp.ts
@@ -1,6 +1,7 @@
 import { postSignUp } from "@api/accountsAPI";
 import { PostSignUpData } from "@api/types/accounts";
 import { useToast } from "@chakra-ui/react";
+import routes from "@constants/routes";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
@@ -14,7 +15,7 @@ const usePostSignUp = () => {
         title: "회원가입이 완료되었습니다.",
         status: "success",
       });
-      navigate("/sign-in");
+      navigate(routes.signIn);
     },
   });
 };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,19 +1,37 @@
+import cn from "@utils/cn";
+import { cva, VariantProps } from "class-variance-authority";
 import { ButtonHTMLAttributes, ReactNode } from "react";
-import { twMerge } from "tailwind-merge";
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+const ButtonVariants = cva(
+  "rounded text-md font-semibold disabled:bg-surface-disable disabled:text-disable",
+  {
+    variants: {
+      style: {
+        filled: "bg-primary-500 text-white hover:bg-primary-700",
+        tonal:
+          "bg-surface-secondary text-primary-700 border-[0.5px] border-primary-200 hover:bg-primary-100 ",
+      },
+    },
+  },
+);
+
+interface ButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "style">,
+    VariantProps<typeof ButtonVariants> {
   children?: ReactNode;
   className?: string;
 }
 
-const Button: React.FC<ButtonProps> = ({ children, className, ...props }) => {
+const Button: React.FC<ButtonProps> = ({
+  style,
+  children,
+  className,
+  ...props
+}) => {
   return (
     <button
       type="button"
-      className={twMerge(
-        "rounded bg-primary-500 text-md font-semibold text-white hover:bg-primary-700 disabled:bg-surface-disable disabled:text-disable",
-        className,
-      )}
+      className={cn(ButtonVariants({ style }), className)}
       {...props}
     >
       {children}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,13 +1,48 @@
 import { LogoIcon } from "@assets/svg";
+import Button from "@components/Button";
+import routes from "@constants/routes";
 import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const Header: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const paths = [routes.main, routes.signIn, routes.signUp, routes.password];
+  const isPathInPaths = paths.includes(
+    location.pathname as (typeof paths)[number],
+  );
+
   return (
-    <header className="flex h-[68px] items-center border-b-1 border-neutral-200 px-7">
-      <div className="flex items-center gap-2">
+    <header className="flex h-[68px] items-center justify-between border-b-1 border-neutral-200 px-7">
+      <button
+        type="button"
+        className="flex items-center gap-2"
+        onClick={() => navigate(isPathInPaths ? routes.main : routes.dashboard)}
+      >
         <LogoIcon />
         <h1 className="text-xl font-semibold">The Monitor</h1>
-      </div>
+      </button>
+      {isPathInPaths && (
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            style="tonal"
+            onClick={() => navigate(routes.signIn)}
+            className="px-3 py-1"
+          >
+            로그인
+          </Button>
+          <Button
+            type="button"
+            style="filled"
+            onClick={() => navigate(routes.signUp)}
+            className="px-3 py-1"
+          >
+            회원가입
+          </Button>
+        </div>
+      )}
     </header>
   );
 };

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,4 +1,5 @@
 const routes = Object.freeze({
+  main: "/",
   signIn: "/sign-in",
   signUp: "/sign-up",
   password: "/password",

--- a/src/pages/FindPassword/components/PasswordSentModal/index.tsx
+++ b/src/pages/FindPassword/components/PasswordSentModal/index.tsx
@@ -1,5 +1,6 @@
 import { CheckboxFillIcon, CloseIcon } from "@assets/svg";
 import Button from "@components/Button";
+import routes from "@constants/routes";
 import React from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -27,7 +28,8 @@ const PasswordSentModal: React.FC<PasswordSentModalProps> = ({ onClose }) => {
           로그인 페이지로 바로 이동됩니다.
         </p>
         <Button
-          onClick={() => navigate("/sign-in")}
+          style="filled"
+          onClick={() => navigate(routes.signIn)}
           className="mt-[29px] h-11 w-[111px]"
         >
           확인

--- a/src/pages/FindPassword/index.tsx
+++ b/src/pages/FindPassword/index.tsx
@@ -78,6 +78,7 @@ const FindPasswordPage: React.FC = () => {
             </div>
             <Button
               type="submit"
+              style="filled"
               disabled={!email || isPending}
               className="mt-11 flex w-full justify-center py-3 text-md font-semibold text-white"
             >

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -88,6 +88,7 @@ const SignInPage: React.FC = () => {
           </div>
           <Button
             type="submit"
+            style="filled"
             disabled={!(email && password)}
             className="mt-[60px] w-full py-3"
           >

--- a/src/pages/SignUp/components/Step1/index.tsx
+++ b/src/pages/SignUp/components/Step1/index.tsx
@@ -96,13 +96,7 @@ const Step1: React.FC<Step1Props> = ({ handleNext }) => {
         <h2 className="text-4xl font-semibold text-title">계정 만들기</h2>
         <div className="flex items-center gap-2">
           <div className="h-3 w-3 rounded-full bg-primary-500" />
-          <button
-            type="button"
-            disabled={isNextStepButtonDisabled}
-            onClick={handleNext}
-          >
-            <div className="h-3 w-3 rounded-full bg-neutral-300" />
-          </button>
+          <div className="h-3 w-3 rounded-full bg-neutral-300" />
         </div>
       </div>
       <div className="mt-9 flex flex-col gap-2">
@@ -123,6 +117,7 @@ const Step1: React.FC<Step1Props> = ({ handleNext }) => {
           />
           <Button
             type="button"
+            style="filled"
             className="flex flex-grow items-center justify-center"
             onClick={handleSendEmailWithTimer}
             disabled={
@@ -149,6 +144,7 @@ const Step1: React.FC<Step1Props> = ({ handleNext }) => {
           />
           <Button
             type="button"
+            style="filled"
             onClick={handleVerifyCode}
             disabled={
               !isEmailSent ||
@@ -210,6 +206,7 @@ const Step1: React.FC<Step1Props> = ({ handleNext }) => {
       </div>
       <Button
         type="button"
+        style="filled"
         disabled={isNextStepButtonDisabled}
         onClick={handleNext}
         className="mt-7 w-full py-3"

--- a/src/pages/SignUp/components/Step2/index.tsx
+++ b/src/pages/SignUp/components/Step2/index.tsx
@@ -3,11 +3,7 @@ import { Checkbox } from "@chakra-ui/react";
 import Button from "@components/Button";
 import { useFormContext } from "react-hook-form";
 
-interface Step2Props {
-  handleBack: () => void;
-}
-
-const Step2: React.FC<Step2Props> = ({ handleBack }) => {
+const Step2: React.FC = () => {
   const {
     register,
     formState: { errors, isValid },
@@ -18,9 +14,7 @@ const Step2: React.FC<Step2Props> = ({ handleBack }) => {
       <div className="mt-[62px] flex items-center justify-between">
         <h2 className="text-4xl font-semibold text-title">정보 작성하기</h2>
         <div className="flex items-center gap-2">
-          <button type="button" onClick={handleBack}>
-            <div className="h-3 w-3 rounded-full bg-neutral-300" />
-          </button>
+          <div className="h-3 w-3 rounded-full bg-neutral-300" />
           <div className="h-3 w-3 rounded-full bg-primary-500" />
         </div>
       </div>
@@ -85,7 +79,12 @@ const Step2: React.FC<Step2Props> = ({ handleBack }) => {
           이용 약관 및 개인정보 수집에 동의합니다
         </span>
       </div>
-      <Button type="submit" disabled={!isValid} className="mt-5 w-full py-3">
+      <Button
+        type="submit"
+        style="filled"
+        disabled={!isValid}
+        className="mt-5 w-full py-3"
+      >
         완료
       </Button>
       <div className="mt-3 flex w-full justify-center">

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export default cn;


### PR DESCRIPTION
## 💻 관련 이슈

<!--
ex) close #100
-->

- close #26

## 💡 작업내용

- 회원가입에서 아이콘 클릭 기능 삭제
- 로그인, 회원가입 버튼 
- 로고 라우팅 기능

## 🧐 참고 사항
![image](https://github.com/user-attachments/assets/785de85a-6a88-483c-9f8f-57d0cbeb481a)
- 버튼 컴포넌트에서 새로운 스타일 추가했습니다. 왼쪽이 filled, 오른쪽이 tonal 입니다. 기존에 버튼 컴포넌트를 사용한 부분이 있다면 style="filled" 인자를 추가해주세요

## 🖼️ 스크린샷

https://github.com/user-attachments/assets/3eccef33-5add-4b46-9e01-273e783a42dc

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
